### PR TITLE
systemctl daemon-reload on service unit file change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,6 @@
   service:
     name: 'oauth2proxy'
     state: 'restarted'
+
+- name: 'systemd-daemon-reload'
+  command: 'systemctl daemon-reload'

--- a/provision-debian-vagrant.sh
+++ b/provision-debian-vagrant.sh
@@ -4,7 +4,7 @@ sudo apt-get install -y python-all-dev python-crypto
 wget https://bootstrap.pypa.io/get-pip.py
 sudo python get-pip.py
 sudo pip install --upgrade pip
-sudo pip install ansible==2.2.0.0
+sudo pip install ansible==2.2.1.0
 echo -ne "[defaults]\nroles_path=/opt/ansible_roles\n" > /home/vagrant/.ansible.cfg
 sudo mkdir -p /opt/ansible_roles
 sudo chown -R vagrant: /opt/ansible_roles

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -15,4 +15,6 @@
     owner: root
     group: root
     mode: '0644'
-  notify: 'restart-ansible-role-oauth2proxy'
+  notify: 
+    - 'systemd-daemon-reload'
+    - 'restart-ansible-role-oauth2proxy'


### PR DESCRIPTION
Oops - I missed this the other day. Sorry.

When a service's unit file changes, you must call `systemctl daemon-reload` before you can perform any operations on the service, e.g. restart.